### PR TITLE
:memo: fixed urls to Veracity documentation pages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,11 +2,11 @@
 
 I'm really glad you're reading this, since we encurage developers to contribute to all and any code we publish on github.
 
-If you haven't already, visit our developers corner at [Veracity Developer](https:\\developer.veracity.com). We want you working on things you're excited about.
+If you haven't already, visit our developers corner at [Veracity Developer](https://developer.veracity.com). We want you working on things you're excited about.
 
 Here are some important resources:
 
-  * [Veracity Developers Documentation](https://developer.veracity.com\docs) tells you where we are,
+  * [Veracity Developers Documentation](https://developer.veracity.com/docs) tells you where we are,
   * Bugs? [Issue tracker](https://github.com/veracity/veracity-quickstart-samples/issues) is where to report them on github code.
 
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This change makes it easier to find https://developer.veracity.com

### Alternate Designs

n/a

### Why Should This Be In Core?

This links to the correct URLs for Veracity developers

### Benefits

Ease of use and correcting typos

### Possible Drawbacks

n/a

### Applicable Issues

n/a
