### PR TITLE
Added an example of how to do user-to-api calls in data-fabric.

### DIFF
--- a/101-datafabric-user-to-api/README.md
+++ b/101-datafabric-user-to-api/README.md
@@ -1,0 +1,29 @@
+# Introduction 
+This sample gives a quick introduction in how to do user-to-api API calls to Veracity Data Fabric, refer to [dev.veracity.com](https://developer.veracity.com/doc/data-fabric-api#overview-0) for documentation on Data API.
+In this sample we do the following:
+- Call /api/1/users/me to get our own user profile
+- Call /api/1/resources to get list of containers shared with our user
+
+
+
+# Notes
+There is currently no way for you as a user to get your access token programatically outside of [onboarded services on Veracity](https://developer.veracity.com/doc/onboarding-a-service). Once you are onboarded you can refer to [this documentation](https://developer.veracity.com/doc/create-veracity-app) on how to create an application for veracity.
+
+For short scripts or small tasks that require automation of our API on your behalf, you can still acquire an access token manually, and then call our APIs programatically. See below under requirements on how to do this.
+
+
+
+# Requirements
+- Access to our api-portal
+- An access-token
+- A subscription key
+
+## API-Portal
+You need access to our [api-portal](https://api-portal.veracity.com/). For help on setting this up, please contact us [here](https://services.veracity.com/form/SupportAnonymous).
+
+## Access Token & Subscription key
+Once logged into our API Portal, navigate to any data fabric endpoint and try them out, this will prompt a login with our identity provider, and post-login you will be able to see your access token and subscription key (press the little 'eye' icon near the subscription key and access token text-fields).
+
+
+# How to run this sample
+Once you have acquired your access token and subscription key, paste their values in `configuration.json`, build and run, you should then in the console see your own profile and a list of containers (if any) shared with you. If you have access only to our production environment, make sure the environment variable in `configuration.json` is set to `Production`.

--- a/101-datafabric-user-to-api/datafabric-user-to-api/datafabric-user-to-api.sln
+++ b/101-datafabric-user-to-api/datafabric-user-to-api/datafabric-user-to-api.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.572
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "datafabric-user-to-api", "datafabric-user-to-api\datafabric-user-to-api.csproj", "{2C140E7F-61FF-4530-A737-D0BA966CC130}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{2C140E7F-61FF-4530-A737-D0BA966CC130}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2C140E7F-61FF-4530-A737-D0BA966CC130}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2C140E7F-61FF-4530-A737-D0BA966CC130}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2C140E7F-61FF-4530-A737-D0BA966CC130}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {82C32705-6660-4C7C-9BDD-922B4A7C7D88}
+	EndGlobalSection
+EndGlobal

--- a/101-datafabric-user-to-api/datafabric-user-to-api/datafabric-user-to-api/DataClient.cs
+++ b/101-datafabric-user-to-api/datafabric-user-to-api/datafabric-user-to-api/DataClient.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+
+namespace datafabric_user_to_api
+{
+    /// <summary>
+    /// A helper class that takes care of authenticated calls towards data fabric api
+    /// </summary>
+    public class DataClient
+    {
+        private readonly HttpClient _httpClient = new HttpClient();
+        private readonly DataClientOptions _options;
+
+
+        public DataClient(IOptions<DataClientOptions> options)
+        {
+            _options = options.Value;
+        }
+
+
+        public async Task<DataFabricProfile> MyProfile()
+        {
+            var request = GetRequestMessageWithAuthorizationHeadersSet();
+            request.RequestUri = new Uri(_options.BaseUrl + "users/me");
+
+            var response = await _httpClient.SendAsync(request);
+            response.EnsureSuccessStatusCode();
+
+            return await DeserializeResponse<DataFabricProfile>(response);
+        }
+
+        public async Task<List<DataFabricContainer>> GetContainersSharedWithMe()
+        {
+            var request = GetRequestMessageWithAuthorizationHeadersSet();
+            request.RequestUri = new Uri(_options.BaseUrl + "resources");
+
+            var response = await _httpClient.SendAsync(request);
+            response.EnsureSuccessStatusCode();
+
+            return await DeserializeResponse<List<DataFabricContainer>>(response);
+        }
+
+        private HttpRequestMessage GetRequestMessageWithAuthorizationHeadersSet()
+        {
+            var token = _options.AccessToken;
+            var subscriptionKey = _options.SubscriptionKey;
+            var request = new HttpRequestMessage(HttpMethod.Get, "");
+            request.Headers.Add("Authorization", token);
+            request.Headers.Add("Ocp-Apim-Subscription-Key", subscriptionKey);
+            return request;
+        }
+
+
+        private static async Task<T> DeserializeResponse<T>(HttpResponseMessage response)
+        {
+            using (var httpStream = await response.Content.ReadAsStreamAsync())
+            using (var streamReader = new StreamReader(httpStream))
+            using (var jsonReader = new JsonTextReader(streamReader))
+            {
+                var serializer = new JsonSerializer();
+                var obj = serializer.Deserialize<T>(jsonReader);
+                return obj;
+            }
+        }
+    }
+}

--- a/101-datafabric-user-to-api/datafabric-user-to-api/datafabric-user-to-api/DataClientOptions.cs
+++ b/101-datafabric-user-to-api/datafabric-user-to-api/datafabric-user-to-api/DataClientOptions.cs
@@ -1,0 +1,38 @@
+﻿using System;
+
+namespace datafabric_user_to_api
+{
+    public class DataClientOptions
+    {
+        public string AccessToken { get; set; }
+        public Environment Env { get; set; }
+
+        public enum Environment
+        {
+            Undefined,
+            Test,
+            Staging,
+            Production
+        }
+
+        public string BaseUrl
+        {
+            get
+            {
+                switch (Env)
+                {
+                    case Environment.Test:
+                        return "https://api-test.veracity.com/veracity/datafabric/data/api/1/";
+                    case Environment.Staging:
+                        return "https://api-stag.veracity.com/veracity/datafabric/data/api/1/";
+                    case Environment.Production:
+                        return "https://api.veracity.com/veracity/datafabric/data/api/1/";
+                    default:
+                        throw new ArgumentOutOfRangeException($"Cannot accept {nameof(Env)} with value {Env}, allowed values are {Environment.Test}, {Environment.Staging} and {Environment.Production}");
+                }
+            }
+        }
+
+        public string SubscriptionKey { get; set; }
+    }
+}

--- a/101-datafabric-user-to-api/datafabric-user-to-api/datafabric-user-to-api/DataFabricApp.cs
+++ b/101-datafabric-user-to-api/datafabric-user-to-api/datafabric-user-to-api/DataFabricApp.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace datafabric_user_to_api
+{
+    /// <summary>
+    /// Simple service that acquires a token from data fabric, calls to check our applications profile and prints the list of containers shared with this user, if any
+    /// </summary>
+    public class DataFabricApp
+    {
+        private readonly DataClient _dataFabricClient;
+
+        public DataFabricApp(DataClient client)
+        {
+            _dataFabricClient = client;
+        }
+
+        public async Task Run()
+        {
+            Console.WriteLine($"========================");
+            var profile = await _dataFabricClient.MyProfile();
+            Console.WriteLine($"My User Profile is: ");
+            PrintProperties(profile);
+
+            Console.WriteLine($"\n========================");
+            Console.WriteLine($"Containers shared with my user:");
+            var containers = await _dataFabricClient.GetContainersSharedWithMe();
+            containers.ForEach(c =>
+            {
+                Console.WriteLine();
+                PrintProperties(c);
+            });
+        }
+
+
+        private void PrintProperties<T>(T obj)
+        {
+            obj.GetType().GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.GetProperty).ToList().ForEach(p =>
+            {
+                Console.WriteLine($"\t {p.Name} : {p.GetValue(obj)}");
+            });
+        }
+    }
+}

--- a/101-datafabric-user-to-api/datafabric-user-to-api/datafabric-user-to-api/DataFabricContainer.cs
+++ b/101-datafabric-user-to-api/datafabric-user-to-api/datafabric-user-to-api/DataFabricContainer.cs
@@ -1,0 +1,40 @@
+﻿using System;
+
+namespace datafabric_user_to_api
+{
+    public class DataFabricContainer
+    {
+        public string id { get; set; }
+        public string reference { get; set; }
+        public string url { get; set; }
+        public DateTime lastModifiedUTC { get; set; }
+        public DateTime creationDateTimeUTC { get; set; }
+        public string ownerId { get; set; }
+        public string accessLevel { get; set; }
+        public string region { get; set; }
+        public string keyStatus { get; set; }
+        public string mayContainPersonalData { get; set; }
+        public Metadata metadata { get; set; }
+    }
+
+    public class Metadata
+    {
+        public string title { get; set; }
+        public string description { get; set; }
+        public Icon icon { get; set; }
+        public Tag[] tags { get; set; }
+    }
+
+    public class Icon
+    {
+        public string id { get; set; }
+        public string backgroundColor { get; set; }
+    }
+
+    public class Tag
+    {
+        public string id { get; set; }
+        public string title { get; set; }
+    }
+
+}

--- a/101-datafabric-user-to-api/datafabric-user-to-api/datafabric-user-to-api/DataFabricProfile.cs
+++ b/101-datafabric-user-to-api/datafabric-user-to-api/datafabric-user-to-api/DataFabricProfile.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace datafabric_user_to_api
+{
+    
+
+    public class DataFabricProfile
+    {
+        public Guid userId { get; set; }
+        public Guid companyId { get; set; }
+        public string role { get; set; }
+    }
+
+}

--- a/101-datafabric-user-to-api/datafabric-user-to-api/datafabric-user-to-api/Program.cs
+++ b/101-datafabric-user-to-api/datafabric-user-to-api/datafabric-user-to-api/Program.cs
@@ -1,0 +1,35 @@
+﻿using System.IO;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace datafabric_user_to_api
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            //You can just load the data client with the required options directly, but setting this console up with Dependency Injection, the transition to using this in .NET Core Web Application will be minimal
+            //Create services
+            var services = new ServiceCollection();
+            ConfigureServices(services);
+
+            //Create service provider
+            var serviceProvider = services.BuildServiceProvider();
+
+            //Run application
+            serviceProvider.GetService<DataFabricApp>().Run().ConfigureAwait(false).GetAwaiter().GetResult();
+        }
+
+        private static void ConfigureServices(IServiceCollection services)
+        {
+            var configuration = new ConfigurationBuilder().SetBasePath(Directory.GetCurrentDirectory())
+                .AddJsonFile($"configuration.json", false, true)
+                .Build();
+
+            services.AddOptions();
+            services.Configure<DataClientOptions>(o => { configuration.GetSection("DataClientOptions").Bind(o); });
+            services.AddTransient<DataClient>();
+            services.AddTransient<DataFabricApp>();
+        }
+    }
+}

--- a/101-datafabric-user-to-api/datafabric-user-to-api/datafabric-user-to-api/configuration.json
+++ b/101-datafabric-user-to-api/datafabric-user-to-api/datafabric-user-to-api/configuration.json
@@ -1,0 +1,7 @@
+{
+  "DataClientOptions": {
+    "AccessToken": "Bearer <access token here>",
+    "SubscriptionKey": "<subscription key here>",
+    "Env":  "Test" 
+  }
+}

--- a/101-datafabric-user-to-api/datafabric-user-to-api/datafabric-user-to-api/datafabric-user-to-api.csproj
+++ b/101-datafabric-user-to-api/datafabric-user-to-api/datafabric-user-to-api/datafabric-user-to-api.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <RootNamespace>datafabric_user_to_api</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="configuration.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
### Description of the Change

A sample of how to call our API as a user, and how to acquire access tokens to do so, until we support direct user login towards identity provider, the workaround is through portal.

### Alternate Designs
- N/A

### Why Should This Be In Core?

- Users may need a sample on how to run short scripts as a user if they want to automate.

### Benefits

- No such sample exists

### Possible Drawbacks

- N/A

### Applicable Issues

- Can use this sample to for example see which containers the user has
